### PR TITLE
Migrate to faststreams

### DIFF
--- a/snappy.nimble
+++ b/snappy.nimble
@@ -5,7 +5,8 @@ description   = "Nim implementation of snappy compression algorithm"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires: "nim >= 0.19.0"
+requires: "nim >= 0.19.0",
+          "faststreams"
 
 task test, "Run all tests":
   exec "nim c --passL:\"-lsnappy -L./tests -lstdc++\" -r tests/test"


### PR DESCRIPTION
The code also features a benchmark comparing the original C++ code for snappy, our old implementation, the new faststreams-based code and an alternative implementation based on Nim's standard streams. Here are some results from the benchmark:

### Benchmark setup:
OS: macOS 10.14.5
CC: clang - Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Hardware: MacBook Pro (13-inch, Mid 2012)
Nim 0.19.6 with "-d:release"

### Compressing 450MB file by first loading it in memory. 

| Variant  | Elapsed time |
| ------------- | ------------- |
| Original code, based on openarrays  | 369 ms  |
| Faststreams implementation  | 366 ms  |
| Nim streams implementation  | 879 ms  |
| C++ implementation (libsnappy) | 113 ms |

