### PR TITLE
Add string versions of compress/uncompress.

### DIFF
--- a/snappy.nim
+++ b/snappy.nim
@@ -502,3 +502,9 @@ template compress*(src: openArray[byte]): seq[byte] =
 
 template uncompress*(src: openArray[byte]): seq[byte] =
   snappy.decode(src)
+  
+template compress*(src: string): string =
+  cast[string](snappy.encode(cast[seq[byte]](src)))
+
+template uncompress*(src: string): string =
+  cast[string](snappy.decode(cast[seq[byte]](src)))


### PR DESCRIPTION
I need to add these two functions when I use this excellent library. I wish they just existed here.

Araq said that cast from seq[byte] to string should always work. This does a zero copy operation and just works.

Thanks!