### PR TITLE
bump cppsnappy, split out benchmark

### DIFF
--- a/snappy.nimble
+++ b/snappy.nimble
@@ -28,9 +28,10 @@ proc test(env, path: string) =
     mkDir "build"
 
   exec "nim " & lang & " " & env &
-    " -r --hints:off --skipParentCfg " & path
+    " --hints:off --skipParentCfg " & path
 
 task test, "Run all tests":
-  test "-d:debug", "tests/all_tests"
-  test "-d:release", "tests/all_tests"
-  test "--threads:on -d:release", "tests/all_tests"
+  test "-d:debug -r", "tests/all_tests"
+  test "-d:release -r", "tests/all_tests"
+  test "--threads:on -d:release -r", "tests/all_tests"
+  test "", "tests/benchmark" # don't run

--- a/tests/benchmark.nim
+++ b/tests/benchmark.nim
@@ -1,0 +1,112 @@
+{.used.}
+
+import
+  os, strformat, stats, times,
+  snappy, openarrays_snappy, nimstreams_snappy, cpp_snappy
+
+const
+  currentDir = currentSourcePath.parentDir
+  dataDir = currentDir & DirSep & "data" & DirSep
+
+type
+  TestTimes = object
+    fastStreams: array[2, RunningStat]
+    openArrays: array[2, RunningStat]
+    nimStreams: array[2, RunningStat]
+    cppLib: array[2, RunningStat]
+    size: int
+
+template timeit(timerVar: var RunningStat, code: untyped) =
+  let t0 = cpuTime()
+  code
+  timerVar.push cpuTime() - t0
+
+var printedHeader = false
+
+proc printTimes(t: TestTimes, name: string) =
+  func f(t: array[2, RunningStat]): string =
+    &"{t[0].mean * 1000 :>7.3f} /{t[1].mean * 1000 :>7.3f}, "
+
+  if not printedHeader:
+    printedHeader = true
+    echo &"{\"fastStreams\" :>16}, {\"openArrays\" :>16}, {\"nimStreams\" :>16}, " &
+      &"{\"cppLib\" :>16}, {\"Samples\" :>12}, {\"Size\" :>12}, {\"Test\" :>12}"
+
+  echo f(t.fastStreams),
+    f(t.openArrays),
+    f(t.nimStreams),
+    f(t.cppLib),
+    &"{t.fastStreams[0].n :>12}, ",
+    &"{t.size :>12}, ",
+    name
+
+proc readSource(sourceName: string): seq[byte] =
+  var f = open(sourceName, fmRead)
+  if f.isNil: return
+  let size = f.getFileSize()
+  result = newSeq[byte](size)
+  doAssert(size == f.readBytes(result, 0, size))
+  f.close()
+
+proc timedRoundTrip(msg: string, source: openarray[byte], iterations = 100) =
+  when declared(GC_fullCollect):
+    GC_fullCollect()
+
+  var timers: TestTimes
+  timers.size = source.len()
+
+  for i in 0..<iterations:
+    timeit(timers.fastStreams[0]):
+      let encodedWithFastStreams = snappy.encode(source)
+
+    timeit(timers.fastStreams[1]):
+      var decodedWithFastStreams = snappy.decode(encodedWithFastStreams)
+
+    timeit(timers.nimStreams[0]):
+      var encodedWithNimStreams = nimstreams_snappy.encode(source)
+
+    timeit(timers.nimStreams[1]):
+      var decodedWithNimStreams = nimstreams_snappy.decode(encodedWithNimStreams)
+
+    timeit(timers.openArrays[0]):
+      var encodedWithOpenArrays = openarrays_snappy.encode(source)
+
+    timeit(timers.openArrays[1]):
+      var decodedWithOpenArrays = openarrays_snappy.decode(encodedWithOpenArrays)
+
+    timeit(timers.cppLib[0]):
+      var encodedWithCpp = cpp_snappy.encode(source)
+
+    timeit(timers.cppLib[1]):
+      var decodedWithCpp = cpp_snappy.decode(encodedWithCpp)
+
+    doAssert decodedWithFastStreams == source
+    doAssert decodedWithNimStreams == source
+    doAssert decodedWithOpenArrays == source
+    doAssert decodedWithCpp == source
+
+  printTimes(timers, msg)
+
+proc roundTrip(msg: string, source: openArray[byte], iterations = 100) =
+  timedRoundTrip(msg, source, iterations)
+
+proc roundTrip(sourceName: string, iterations = 100) =
+  var src = readSource(sourceName)
+  roundTrip(extractFilename(sourceName), src, iterations)
+
+roundTrip(dataDir & "html")
+roundTrip(dataDir & "urls.10K")
+roundTrip(dataDir & "fireworks.jpeg")
+roundTrip(dataDir & "paper-100k.pdf")
+roundTrip(dataDir & "html_x_4")
+roundTrip(dataDir & "alice29.txt")
+roundTrip(dataDir & "asyoulik.txt")
+roundTrip(dataDir & "lcet10.txt")
+roundTrip(dataDir & "plrabn12.txt")
+roundTrip(dataDir & "geo.protodata")
+roundTrip(dataDir & "kppkn.gtb")
+roundTrip(dataDir & "Mark.Twain-Tom.Sawyer.txt")
+
+# ncli_db --db:db dumpState 0x114a593d248af2ad05580299b803657d4b78a3b6578f47425cc396c9644e800e 2560000
+if fileExists(dataDir & "state-2560000-114a593d-0d5e08e8.ssz"):
+  roundTrip(dataDir & "state-2560000-114a593d-0d5e08e8.ssz", 10)

--- a/tests/build_snappycpp.sh
+++ b/tests/build_snappycpp.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd snappycpp
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ../
+
+make snappy
+cp libsnappy.a ../..

--- a/tests/cpp_snappy.nim
+++ b/tests/cpp_snappy.nim
@@ -1,0 +1,46 @@
+import std/os
+
+const
+  currentDir = currentSourcePath.parentDir
+
+{.passl: "-lsnappy -L\"" & currentDir & "\" -lstdc++".}
+
+proc snappy_compress*(input: cstring, input_length: csize_t, compressed: ptr cchar, compressed_length: var csize_t): cint {.importc, cdecl.}
+proc snappy_uncompress*(compressed: cstring, compressed_length: csize_t, uncompressed: ptr cchar, uncompressed_length: var csize_t): cint {.importc, cdecl.}
+proc snappy_max_compressed_length*(source_length: csize_t): csize_t {.importc, cdecl.}
+proc snappy_uncompressed_length*(compressed: cstring, compressed_length: csize_t, res: var csize_t): cint {.importc, cdecl.}
+
+proc encode*(input: openArray[byte]): seq[byte] =
+  result = newSeqUninitialized[byte](
+    snappy_max_compressed_length(input.len.csize_t))
+  var bytes = result.len.csize_t
+  let res = if input.len() == 0:
+    snappy_compress(nil, 0, cast[ptr cchar](result[0].addr), bytes)
+  else:
+    snappy_compress(
+      cast[cstring](unsafeAddr input[0]), input.len().csize_t,
+      cast[ptr cchar](result[0].addr), bytes)
+  if res != 0:
+    raise (ref ValueError)(msg: "Cannot compress")
+
+  result.setLen(bytes.int)
+
+proc decode*(input: openArray[byte]): seq[byte] =
+  if input.len() == 0:
+    raise (ref ValueError)(msg: "empty input")
+
+  var bytes: csize_t
+  if snappy_uncompressed_length(
+    cast[cstring](input[0].unsafeAddr), input.len.csize_t, bytes) != 0:
+    raise (ref ValueError)(msg: "Cannot get length")
+
+  if bytes == 0:
+    return
+
+  result = newSeqUninitialized[byte](bytes.int)
+
+
+  if snappy_uncompress(
+      cast[cstring](unsafeAddr input[0]), input.len().csize_t,
+      cast[ptr cchar](result[0].addr), bytes) != 0:
+    raise (ref ValueError)(msg: "Cannot compress")


### PR DESCRIPTION
* benchmark both compression and decompression
* bump C++-snappy: it's gotten better over the years

```
fastStreams,       openArrays,       nimStreams,           cppLib,      Samples,         Size,         Test
  0.281 /  0.139,   0.295 /  0.220,   0.528 /  0.238,   0.140 /  0.047,          100,       102400, html
  2.697 /  1.457,   3.263 /  1.993,   6.106 /  2.026,   1.655 /  0.530,          100,       702087, urls.10K
  0.021 /  0.011,   0.017 /  0.011,   0.031 /  0.011,   0.014 /  0.009,          100,       123093, fireworks.jpeg
  0.057 /  0.019,   0.051 /  0.036,   0.092 /  0.042,   0.021 /  0.011,          100,       102400, paper-100k.pdf
  1.153 /  0.565,   1.210 /  0.904,   2.172 /  0.985,   0.575 /  0.184,          100,       409600, html_x_4
  0.887 /  0.582,   0.976 /  0.743,   1.923 /  0.712,   0.536 /  0.202,          100,       152089, alice29.txt
  0.771 /  0.504,   0.850 /  0.639,   1.678 /  0.606,   0.482 /  0.184,          100,       129301, asyoulik.txt
  2.349 /  1.518,   2.553 /  1.946,   5.057 /  1.913,   1.391 /  0.522,          100,       426754, lcet10.txt
  2.983 /  1.951,   3.241 /  2.408,   6.680 /  2.342,   1.882 /  0.735,          100,       481861, plrabn12.txt
  0.293 /  0.120,   0.306 /  0.210,   0.542 /  0.241,   0.131 /  0.042,          100,       118588, geo.protodata
  0.743 /  0.501,   0.738 /  0.620,   1.597 /  0.640,   0.414 /  0.191,          100,       184320, kppkn.gtb
  0.087 /  0.054,   0.102 /  0.067,   0.193 /  0.061,   0.052 /  0.022,          100,        14564, Mark.Twain-Tom.Sawyer.txt
 66.886 / 20.880, 105.393 / 37.907, 210.197 / 38.867,  34.273 / 10.193,           10,     38942424, state-2560000-114a593d-0d5e08e8.ssz
```

In general, we're consistently about 2x slower than C++ right now.