### PR TITLE
deduplicate and reorganise code

### DIFF
--- a/snappy.nim
+++ b/snappy.nim
@@ -1,356 +1,25 @@
 import
-  stew/[leb128, ranges/ptr_arith, arrayops, endians2],
+  stew/[leb128, ranges/ptr_arith],
   faststreams/[inputs, outputs, buffers, multisync],
-  snappy/types
+  ./snappy/[codec, decoder, encoder_fs, types]
 
 export
   types
 
-const
-  tagLiteral* = 0x00
-  tagCopy1*   = 0x01
-  tagCopy2*   = 0x02
-  tagCopy4*   = 0x03
-
-  inputMargin = 16 - 1
-
-# emitLiteral writes a literal chunk.
-#
-# It assumes that:
-#  1 <= len(lit) and len(lit) <= 65536
-proc emitLiteral(s: OutputStream, lit: openarray[byte]) =
-  let n = lit.len - 1
-
-  if n < 60:
-    s.write (byte(n) shl 2) or tagLiteral
-  elif n < (1 shl 8):
-    s.write (60 shl 2) or tagLiteral
-    s.write byte(n and 0xFF)
-  else:
-    s.write (61 shl 2) or tagLiteral
-    s.write byte(n and 0xFF)
-    s.write byte((n shr 8) and 0xFF)
-
-  s.writeAndWait lit
-
-# emitCopy writes a copy chunk.
-#
-# It assumes that:
-#  1 <= offset and offset <= 65535
-#  4 <= length and length <= 65535
-proc emitCopy(s: OutputStream, offset, length: int) =
-  var length = length
-  # The maximum length for a single tagCopy1 or tagCopy2 op is 64 bytes. The
-  # threshold for this loop is a little higher (at 68 = 64 + 4), and the
-  # length emitted down below is is a little lower (at 60 = 64 - 4), because
-  # it's shorter to encode a length 67 copy as a length 60 tagCopy2 followed
-  # by a length 7 tagCopy1 (which encodes as 3+2 bytes) than to encode it as
-  # a length 64 tagCopy2 followed by a length 3 tagCopy2 (which encodes as
-  # 3+3 bytes). The magic 4 in the 64±4 is because the minimum length for a
-  # tagCopy1 op is 4 bytes, which is why a length 3 copy has to be an
-  # encodes-as-3-bytes tagCopy2 instead of an encodes-as-2-bytes tagCopy1.
-  while length >= 68:
-    # Emit a length 64 copy, encoded as 3 bytes.
-    s.write (63 shl 2) or tagCopy2
-    s.write byte(offset and 0xFF)
-    s.write byte((offset shr 8) and 0xFF)
-    dec(length, 64)
-
-  if length > 64:
-    # Emit a length 60 copy, encoded as 3 bytes.
-    s.write (59 shl 2) or tagCopy2
-    s.write byte(offset and 0xFF)
-    s.write byte((offset shr 8) and 0xFF)
-    dec(length, 60)
-
-  if (length >= 12) or (offset >= 2048):
-    # Emit the remaining copy, encoded as 3 bytes.
-    s.write byte((((length-1) shl 2) or tagCopy2) and 0xFF)
-    s.write byte(offset and 0xFF)
-    s.write byte((offset shr 8) and 0xFF)
-    return
-
-  s.write byte((((offset shr 8) shl 5) or ((length-4) shl 2) or tagCopy1) and 0xFF)
-  s.write byte(offset and 0xFF)
-
-when false:
-  # extendMatch returns the largest k such that k <= len(src) and that
-  # src[i:i+k-j] and src[j:k] have the same contents.
-  #
-  # It assumes that:
-  #  0 <= i and i < j and j <= len(src)
-  func extendMatch(src: openArray[byte], i, j: int): int =
-    var
-      i = i
-      j = j
-    while j < src.len and src[i] == src[j]:
-      inc i
-      inc j
-    result = j
-
-func hash(u, shift: uint32): uint32 =
-  result = (u * 0x1e35a7bd) shr shift
-
-# encodeBlock encodes a non-empty src to a guaranteed-large-enough dst. It
-# assumes that the varint-encoded length of the decompressed bytes has already
-# been written.
-#
-# It also assumes that:
-#  len(dst) >= maxCompressedLen(len(src)) and
-#  minNonLiteralBlockSize <= len(src) and len(src) <= maxBlockSize
-proc encodeBlock(output: OutputStream, src: openArray[byte]) =
-  # Initialize the hash table. Its size ranges from 1shl8 to 1shl14 inclusive.
-  # The table element type is uint16, as s < sLimit and sLimit < len(src)
-  # and len(src) <= maxBlockSize and maxBlockSize == 65536.
-  const
-    maxTableSize = 1 shl 14
-    # tableMask is redundant, but helps the compiler eliminate bounds
-    # checks.
-    tableMask = maxTableSize - 1
-
-  var
-    shift = 32 - 8
-    tableSize = 1 shl 8
-
-  while tableSize < maxTableSize and tableSize < src.len:
-    tableSize = tableSize * 2
-    dec shift
-
-  # In Nim, all array elements are zero-initialized, so there is no advantage
-  # to a smaller tableSize per se. However, it matches the C++ algorithm,
-  # and in the asm versions of this code, we can get away with zeroing only
-  # the first tableSize elements.
-  var table: array[maxTableSize, uint16]
-
-  # sLimit is when to stop looking for offset/length copies. The inputMargin
-  # lets us use a fast path for emitLiteral in the main loop, while we are
-  # looking for copies.
-  var sLimit = src.len - inputMargin
-  # nextEmit is where in src the next emitLiteral should start from.
-  var nextEmit = 0
-
-  # The encoded form must start with a literal, as there are no previous
-  # bytes to copy, so we start looking for hash matches at s == 1.
-  var s = 1
-  var nextHash = hash(fromBytesLE(uint32, src.toOpenArray(s, s+3)), shift.uint32)
-
-  template emitRemainder(): untyped =
-    if nextEmit < src.len:
-      emitLiteral(output, src.toOpenArray(nextEmit, src.high))
-    return
-
-  while true:
-    # Copied from the C++ snappy implementation:
-    #
-    # Heuristic match skipping: If 32 bytes are scanned with no matches
-    # found, start looking only at every other byte. If 32 more bytes are
-    # scanned (or skipped), look at every third byte, etc.. When a match
-    # is found, immediately go back to looking at every byte. This is a
-    # small loss (~5% performance, ~0.1% density) for compressible data
-    # due to more bookkeeping, but for non-compressible data (such as
-    # JPEG) it's a huge win since the compressor quickly "realizes" the
-    # data is incompressible and doesn't bother looking for matches
-    # everywhere.
-    #
-    # The "skip" variable keeps track of how many bytes there are since
-    # the last match; dividing it by 32 (ie. right-shifting by five) gives
-    # the number of bytes to move ahead for each iteration.
-    var skip = 32
-
-    var nextS = s
-    var candidate = 0
-    while true:
-      s = nextS
-      let bytesBetweenHashLookups = skip shr 5
-      nextS = s + bytesBetweenHashLookups
-      inc(skip, bytesBetweenHashLookups)
-      if nextS > sLimit:
-        emitRemainder()
-
-      candidate = int(table[nextHash and tableMask])
-      table[nextHash and tableMask] = uint16(s)
-      nextHash = hash(fromBytesLE(uint32, src.toOpenArray(nextS, nextS+3)), shift.uint32)
-      if fromBytesLE(uint32, src.toOpenArray(s, s+3)) == fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
-        break
-
-    # A 4-byte match has been found. We'll later see if more than 4 bytes
-    # match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
-    # them as literal bytes.
-    output.emitLiteral src.toOpenArray(nextEmit, s - 1)
-
-    # Call emitCopy, and then see if another emitCopy could be our next
-    # move. Repeat until we find no match for the input immediately after
-    # what was consumed by the last emitCopy call.
-    #
-    # If we exit this loop normally then we need to call emitLiteral next,
-    # though we don't yet know how big the literal will be. We handle that
-    # by proceeding to the next iteration of the main loop. We also can
-    # exit this loop via goto if we get close to exhausting the input.
-    while true:
-      # Invariant: we have a 4-byte match at s, and no need to emit any
-      # literal bytes prior to s.
-      var base = s
-
-      # Extend the 4-byte match as long as possible.
-      #
-      # This is an inlined version of:
-      #  s = extendMatch(src, candidate+4, s+4)
-      inc(s, 4)
-      var i = candidate + 4
-      while s < src.len and src[i] == src[s]:
-        inc i
-        inc s
-
-      output.emitCopy(base-candidate, s-base)
-      nextEmit = s
-      if s >= sLimit:
-        emitRemainder()
-
-      # We could immediately start working at s now, but to improve
-      # compression we first update the hash table at s-1 and at s. If
-      # another emitCopy is not our next move, also calculate nextHash
-      # at s+1. At least on ARCH=amd64, these three hash calculations
-      # are faster as one load64 call (with some shifts) instead of
-      # three load32 calls.
-      let x = fromBytesLE(uint64, src.toOpenArray(s-1, src.len-1))
-      let prevHash = hash(uint32(x shr 0), shift.uint32)
-      table[prevHash and tableMask] = uint16(s - 1)
-      let currHash = hash(uint32(x shr 8), shift.uint32)
-      candidate = int(table[currHash and tableMask])
-      table[currHash and tableMask] = uint16(s)
-      if uint32(x shr 8) != fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
-        nextHash = hash(uint32(x shr 16), shift.uint32)
-        inc s
-        break
-
-const
-  decodeErrCodeCorrupt = 1
-  decodeErrCodeUnsupportedLiteralLength = 2
-
-func decode(dst: var openArray[byte], src: openArray[byte]): int =
-  var
-    d = 0
-    s = 0
-    offset = 0
-    length = 0
-
-  while s < src.len:
-    let tag = src[s] and 0x03
-    case tag
-    of tagLiteral:
-      var x = int(src[s]) shr 2
-      if x < 60:
-        inc s
-      elif x == 60:
-        inc(s, 2)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-1])
-      elif x == 61:
-        inc(s, 3)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-2]) or (int(src[s-1]) shl 8)
-      elif x == 62:
-        inc(s, 4)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-3]) or (int(src[s-2]) shl 8) or (int(src[s-1]) shl 16)
-      elif x == 63:
-        inc(s, 5)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
-      length = x + 1
-      if length <= 0:
-        return decodeErrCodeUnsupportedLiteralLength
-
-      if (length > (dst.len-d)) or (length > (src.len-s)):
-        return decodeErrCodeCorrupt
-
-      dst[d..<d+length] = src.toOpenArray(s, s+length-1)
-      inc(d, length)
-      inc(s, length)
-      continue
-
-    of tagCopy1:
-      inc(s, 2)
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 4 + ((int(src[s-2]) shr 2) and 0x07)
-      offset = ((int(src[s-2]) and 0xe0) shl 3) or int(src[s-1])
-
-    of tagCopy2:
-      s += 3
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 1 + (int(src[s-3]) shr 2)
-      offset = int(src[s-2]) or (int(src[s-1]) shl 8)
-
-    of tagCopy4:
-      s += 5
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 1 + (int(src[s-5]) shr 2)
-      offset = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
-
-    else: discard
-
-    if offset <= 0 or d < offset or (length > (dst.len-d)):
-      return decodeErrCodeCorrupt
-
-    # Copy from an earlier sub-slice of dst to a later sub-slice. Unlike
-    # the built-in copy function, this byte-by-byte copy always runs
-    # forwards, even if the slices overlap. Conceptually, this is:
-    #
-    # d += forwardCopy(dst[d:d+length], dst[d-offset:])
-    let stop = d + length
-    while d != stop:
-      dst[d] = dst[d-offset]
-      inc d
-
-  if d != dst.len:
-    return decodeErrCodeCorrupt
-  return 0
-
-# minNonLiteralBlockSize is the minimum size of the input to encodeBlock that
-# could be encoded with a copy tag. This is the minimum with respect to the
-# algorithm used by encodeBlock, not a minimum enforced by the file format.
-#
-# The encoded output must start with at least a 1 byte literal, as there are
-# no previous bytes to copy. A minimal (1 byte) copy after that, generated
-# from an emitCopy call in encodeBlock's main loop, would require at least
-# another inputMargin bytes, for the reason above: we want any emitLiteral
-# calls inside encodeBlock's main loop to use the fast path if possible, which
-# requires being able to overrun by inputMargin bytes. Thus,
-# minNonLiteralBlockSize equals 1 + 1 + inputMargin.
-#
-# The C++ code doesn't use this exact threshold, but it could, as discussed at
-# https:#groups.google.com/d/topic/snappy-compression/oGbhsdIJSJ8/discussion
-# The difference between Nim (2+inputMargin) and C++ (inputMargin) is purely an
-# optimization. It should not affect the encoded form. This is tested by
-# TestSameEncodingAsCppShortCopies.
-const
-  minNonLiteralBlockSize* = 1 + 1 + inputMargin
-
-# Encode returns the encoded form of src. The returned slice may be a sub-
-# slice of dst if dst was large enough to hold the entire encoded block.
-# Otherwise, a newly allocated slice will be returned.
-#
-# The dst and src must not overlap. It is valid to pass a nil dst.
 proc appendSnappyBytes*(s: OutputStream, src: openArray[byte]) =
   var
-    lenU32 = checkInputLen(src.len)
+    lenU32 = checkInputLen(src.len).valueOr:
+      raiseInputTooLarge()
     p = 0
 
   # The block starts with the varint-encoded length of the decompressed bytes.
   s.write lenU32.toBytes(Leb128).toOpenArray()
   if lenU32 <= 0: return
 
-  while lenU32 > maxBlockSize.uint32:
-    s.encodeBlock src.toOpenArray(p, p + maxBlockSize - 1)
-    p += maxBlockSize
-    lenU32 -= maxBlockSize.uint32
+  while lenU32 > maxBlockSize:
+    s.encodeBlock src.toOpenArray(p, p + maxBlockSize.int - 1)
+    p += maxBlockSize.int
+    lenU32 -= maxBlockSize
 
   # The `lenU32.int` expressions below cannot overflow because
   # `lenU32` is already less than `maxBlockSize` here:
@@ -363,15 +32,20 @@ proc snappyCompress*(input: InputStream, output: OutputStream) =
   try:
     let inputLen = input.len
     if inputLen.isSome:
-      let lenU32 = checkInputLen(inputLen.get)
-      output.ensureRunway maxCompressedLen(lenU32)
+      let
+        lenU32 = checkInputLen(inputLen.get).valueOr:
+          raiseInputTooLarge()
+        maxCompressed = maxCompressedLen(lenU32).valueOr:
+          raiseInputTooLarge()
+
+      output.ensureRunway maxCompressed
       output.write lenU32.toBytes(Leb128).toOpenArray()
     else:
       # TODO: This is a temporary limitation
       doAssert false, "snappy requires an input stream with a known length"
 
-    while input.readable(maxBlockSize):
-      encodeBlock(output, input.read(maxBlockSize))
+    while input.readable(maxBlockSize.int):
+      encodeBlock(output, input.read(maxBlockSize.int))
 
     let remainingBytes = input.totalUnconsumedBytes
     if remainingBytes > 0:
@@ -405,16 +79,16 @@ func decode*(src: openArray[byte], maxSize = 0xffffffff'u32): seq[byte] =
     if errCode != 0: result = @[]
 
 proc snappyUncompress*(src: openArray[byte], dst: var openArray[byte]): uint32 =
-  let (uncompressedLen, bytesRead) = uint32.fromBytes(src, Leb128)
-  if bytesRead <= 0 or uncompressedLen.BiggestUInt > dst.len.BiggestUInt:
+  let (lenU32, bytesRead) = uint32.fromBytes(src, Leb128)
+  if bytesRead <= 0 or lenU32.BiggestUInt > dst.len.BiggestUInt:
     return 0
 
-  if uncompressedLen > 0:
+  if lenU32 > 0:
     # `result.int` cannot overflow here, because we've already
     # checked that it's smaller than the `dst.len` which is an int.
-    let errCode = decode(dst.toOpenArray(0, uncompressedLen.int - 1),
+    let errCode = decode(dst.toOpenArray(0, lenU32.int - 1),
                          src.toOpenArray(bytesRead, src.len - 1))
     if errCode != 0:
       return 0
 
-  return uncompressedLen
+  return lenU32

--- a/snappy.nimble
+++ b/snappy.nimble
@@ -7,8 +7,9 @@ description   = "Nim implementation of snappy compression algorithm"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires "nim >= 0.19.0",
+requires "nim >= 1.2.0",
          "faststreams",
+         "unittest2",
          "stew"
 
 ### Helper functions
@@ -23,4 +24,4 @@ task test, "Run all tests":
   test "-d:debug -r", "tests/all_tests"
   test "-d:release -r", "tests/all_tests"
   test "--threads:on -d:release -r", "tests/all_tests"
-  test "", "tests/benchmark" # don't run
+  test "-d:release", "tests/benchmark" # don't run

--- a/snappy/codec.nim
+++ b/snappy/codec.nim
@@ -1,0 +1,82 @@
+import
+  stew/results
+
+export results
+
+const
+  tagLiteral* = 0x00
+  tagCopy1*   = 0x01
+  tagCopy2*   = 0x02
+  tagCopy4*   = 0x03
+
+  inputMargin* = 16 - 1
+
+  maxUncompressedLen* = 0xffffffff'u32
+  maxBlockSize* = 65536'u32
+
+# minNonLiteralBlockSize is the minimum size of the input to encodeBlock that
+# could be encoded with a copy tag. This is the minimum with respect to the
+# algorithm used by encodeBlock, not a minimum enforced by the file format.
+#
+# The encoded output must start with at least a 1 byte literal, as there are
+# no previous bytes to copy. A minimal (1 byte) copy after that, generated
+# from an emitCopy call in encodeBlock's main loop, would require at least
+# another inputMargin bytes, for the reason above: we want any emitLiteral
+# calls inside encodeBlock's main loop to use the fast path if possible, which
+# requires being able to overrun by inputMargin bytes. Thus,
+# minNonLiteralBlockSize equals 1 + 1 + inputMargin.
+#
+# The C++ code doesn't use this exact threshold, but it could, as discussed at
+# https:#groups.google.com/d/topic/snappy-compression/oGbhsdIJSJ8/discussion
+# The difference between Nim (2+inputMargin) and C++ (inputMargin) is purely an
+# optimization. It should not affect the encoded form. This is tested by
+# TestSameEncodingAsCppShortCopies.
+const
+  minNonLiteralBlockSize* = 1 + 1 + inputMargin
+
+func checkInputLen*(srcLen: int): Opt[uint32] =
+  static: doAssert uint32.high.uint64 <= maxUncompressedLen.uint64
+  if srcLen.uint64 > maxUncompressedLen.uint64:
+    err()
+  else:
+    ok(srcLen.uint32)
+
+func maxCompressedLen*(srcLen: uint32): Opt[int] =
+  ## Return the maximum number of bytes needed to encode an input of the given
+  ## length - fails when input exceeds maxUncompressedLen or output
+  ## see also snappy::MaxCompressedLength
+
+  # Compressed data can be defined as:
+  #    compressed := item* literal*
+  #    item       := literal* copy
+  #
+  # The trailing literal sequence has a space blowup of at most 62/60
+  # since a literal of length 60 needs one tag byte + one extra byte
+  # for length information.
+  #
+  # Item blowup is trickier to measure. Suppose the "copy" op copies
+  # 4 bytes of data. Because of a special check in the encoding code,
+  # we produce a 4-byte copy only if the offset is < 65536. Therefore
+  # the copy op takes 3 bytes to encode, and this type of item leads
+  # to at most the 62/60 blowup for representing literals.
+  #
+  # Suppose the "copy" op copies 5 bytes of data. If the offset is big
+  # enough, it will take 5 bytes to encode the copy op. Therefore the
+  # worst case here is a one-byte literal followed by a five-byte copy.
+  # That is, 6 bytes of input turn into 7 bytes of "compressed" data.
+  #
+  # This last factor dominates the blowup, so the final estimate is:
+  static:
+    doAssert sizeof(int) <= sizeof(uint64),
+      "did we get to 128-bit ints already???"
+
+  let
+    n = srcLen.uint64
+    max = 32'u64 + n + n div 6'u64
+  if max > int.high.uint64: # for 32-bit platforms..
+    err()
+  else:
+    ok(int(max))
+
+func hash*(u, shift: uint32): uint32 =
+  (u * 0x1e35a7bd'u32) shr shift

--- a/snappy/decoder.nim
+++ b/snappy/decoder.nim
@@ -1,0 +1,93 @@
+import
+  stew/[arrayops],
+  ./codec
+
+const
+  decodeErrCodeCorrupt = 1
+  decodeErrCodeUnsupportedLiteralLength = 2
+
+func decode*(dst: var openArray[byte], src: openArray[byte]): int =
+  var
+    d = 0
+    s = 0
+    offset = 0
+    length = 0
+
+  while s < src.len:
+    let tag = src[s] and 0x03
+    case tag
+    of tagLiteral:
+      var x = int(src[s]) shr 2
+      if x < 60:
+        inc s
+      elif x == 60:
+        inc(s, 2)
+        if s > src.len:
+          return decodeErrCodeCorrupt
+        x = int(src[s-1])
+      elif x == 61:
+        inc(s, 3)
+        if s > src.len:
+          return decodeErrCodeCorrupt
+        x = int(src[s-2]) or (int(src[s-1]) shl 8)
+      elif x == 62:
+        inc(s, 4)
+        if s > src.len:
+          return decodeErrCodeCorrupt
+        x = int(src[s-3]) or (int(src[s-2]) shl 8) or (int(src[s-1]) shl 16)
+      elif x == 63:
+        inc(s, 5)
+        if s > src.len:
+          return decodeErrCodeCorrupt
+        x = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
+      length = x + 1
+      if length <= 0:
+        return decodeErrCodeUnsupportedLiteralLength
+
+      if (length > (dst.len-d)) or (length > (src.len-s)):
+        return decodeErrCodeCorrupt
+
+      dst[d..<d+length] = src.toOpenArray(s, s+length-1)
+      inc(d, length)
+      inc(s, length)
+      continue
+
+    of tagCopy1:
+      inc(s, 2)
+      if s > src.len:
+        return decodeErrCodeCorrupt
+      length = 4 + ((int(src[s-2]) shr 2) and 0x07)
+      offset = ((int(src[s-2]) and 0xe0) shl 3) or int(src[s-1])
+
+    of tagCopy2:
+      s += 3
+      if s > src.len:
+        return decodeErrCodeCorrupt
+      length = 1 + (int(src[s-3]) shr 2)
+      offset = int(src[s-2]) or (int(src[s-1]) shl 8)
+
+    of tagCopy4:
+      s += 5
+      if s > src.len:
+        return decodeErrCodeCorrupt
+      length = 1 + (int(src[s-5]) shr 2)
+      offset = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
+
+    else: discard
+
+    if offset <= 0 or d < offset or (length > (dst.len-d)):
+      return decodeErrCodeCorrupt
+
+    # Copy from an earlier sub-slice of dst to a later sub-slice. Unlike
+    # the built-in copy function, this byte-by-byte copy always runs
+    # forwards, even if the slices overlap. Conceptually, this is:
+    #
+    # d += forwardCopy(dst[d:d+length], dst[d-offset:])
+    let stop = d + length
+    while d != stop:
+      dst[d] = dst[d-offset]
+      inc d
+
+  if d != dst.len:
+    return decodeErrCodeCorrupt
+  return 0

--- a/snappy/encoder_oa.nim
+++ b/snappy/encoder_oa.nim
@@ -1,0 +1,213 @@
+import
+  stew/[endians2, leb128, arrayops],
+  ./codec
+
+# emitLiteral writes a literal chunk and returns the number of bytes written.
+#
+# It assumes that:
+#  dst is long enough to hold the encoded bytes
+#  1 <= len(lit) and len(lit) <= 65536
+func emitLiteral*(dst: var openArray[byte], d: int, lit: openArray[byte]): int =
+  var
+    i = d
+    n = lit.len-1
+
+  if n < 60:
+    dst[i + 0] = (byte(n) shl 2) or tagLiteral
+    inc(i)
+  elif n < (1 shl 8):
+    dst[i + 0] = (60 shl 2) or tagLiteral
+    dst[i + 1] = byte(n)
+    inc(i, 2)
+  else:
+    dst[i + 0] = (61 shl 2) or tagLiteral
+    dst[i + 1] = byte(n and 0xFF)
+    dst[i + 2] = byte((n shr 8) and 0xFF)
+    inc(i, 3)
+
+  dst[i..<i+lit.len] = lit
+
+  i + lit.len - d
+
+# emitCopy writes a copy chunk and returns the number of bytes written.
+#
+# It assumes that:
+#  dst is long enough to hold the encoded bytes
+#  1 <= offset and offset <= 65535
+#  4 <= length and length <= 65535
+func emitCopy(dst: var openArray[byte], d, offset, length: int): int =
+  var
+    i = d
+    length = length
+  # The maximum length for a single tagCopy1 or tagCopy2 op is 64 bytes. The
+  # threshold for this loop is a little higher (at 68 = 64 + 4), and the
+  # length emitted down below is is a little lower (at 60 = 64 - 4), because
+  # it's shorter to encode a length 67 copy as a length 60 tagCopy2 followed
+  # by a length 7 tagCopy1 (which encodes as 3+2 bytes) than to encode it as
+  # a length 64 tagCopy2 followed by a length 3 tagCopy2 (which encodes as
+  # 3+3 bytes). The magic 4 in the 64±4 is because the minimum length for a
+  # tagCopy1 op is 4 bytes, which is why a length 3 copy has to be an
+  # encodes-as-3-bytes tagCopy2 instead of an encodes-as-2-bytes tagCopy1.
+  while length >= 68:
+    # Emit a length 64 copy, encoded as 3 bytes.
+    dst[i+0] = (63 shl 2) or tagCopy2
+    dst[i+1] = byte(offset and 0xFF)
+    dst[i+2] = byte((offset shr 8) and 0xFF)
+    inc(i, 3)
+    dec(length, 64)
+
+  if length > 64:
+    # Emit a length 60 copy, encoded as 3 bytes.
+    dst[i+0] = (59 shl 2) or tagCopy2
+    dst[i+1] = byte(offset and 0xFF)
+    dst[i+2] = byte((offset shr 8) and 0xFF)
+    inc(i, 3)
+    dec(length, 60)
+
+  if (length >= 12) or (offset >= 2048):
+    # Emit the remaining copy, encoded as 3 bytes.
+    dst[i+0] = (byte(length-1) shl 2) or tagCopy2
+    dst[i+1] = byte(offset and 0xFF)
+    dst[i+2] = byte((offset shr 8) and 0xFF)
+    return i + 3 - d
+
+  # Emit the remaining copy, encoded as 2 bytes.
+  dst[i+0] = byte((((offset shr 8) shl 5) or ((length-4) shl 2) or tagCopy1) and 0xFF)
+  dst[i+1] = byte(offset and 0xFF)
+
+  i + 2 - d
+
+# encodeBlock encodes a non-empty src to a guaranteed-large-enough dst. It
+# assumes that the varint-encoded length of the decompressed bytes has already
+# been written.
+#
+# It also assumes that:
+#  len(dst) >= MaxEncodedLen(len(src)) and
+#  minNonLiteralBlockSize <= len(src) and len(src) <= maxBlockSize
+func encodeBlock*(dst: var openArray[byte], offset: int, src: openArray[byte]): int =
+  # Initialize the hash table. Its size ranges from 1shl8 to 1shl14 inclusive.
+  # The table element type is uint16, as s < sLimit and sLimit < len(src)
+  # and len(src) <= maxBlockSize and maxBlockSize == 65536.
+  const
+    maxTableSize = 1 shl 14
+    # tableMask is redundant, but helps the compiler eliminate bounds
+    # checks.
+    tableMask = maxTableSize - 1
+
+  var
+    shift = 32 - 8
+    tableSize = 1 shl 8
+
+  while tableSize < maxTableSize and tableSize < src.len:
+    tableSize = tableSize * 2
+    dec shift
+
+  # In Nim, all array elements are zero-initialized, so there is no advantage
+  # to a smaller tableSize per se. However, it matches the C++ algorithm,
+  # and in the asm versions of this code, we can get away with zeroing only
+  # the first tableSize elements.
+  var table: array[maxTableSize, uint16]
+
+  # sLimit is when to stop looking for offset/length copies. The inputMargin
+  # lets us use a fast path for emitLiteral in the main loop, while we are
+  # looking for copies.
+  var sLimit = src.len - inputMargin
+  # nextEmit is where in src the next emitLiteral should start from.
+  var nextEmit = 0
+
+  # The encoded form must start with a literal, as there are no previous
+  # bytes to copy, so we start looking for hash matches at s == 1.
+  var s = 1
+  var nextHash = hash(fromBytesLE(uint32, src.toOpenArray(s, s+3)), shift.uint32)
+  var d = offset
+
+  template emitRemainder(): untyped =
+    if nextEmit < src.len:
+      d += emitLiteral(dst, d, src.toOpenArray(nextEmit, src.high))
+    return d - offset
+
+  while true:
+    # Copied from the C++ snappy implementation:
+    #
+    # Heuristic match skipping: If 32 bytes are scanned with no matches
+    # found, start looking only at every other byte. If 32 more bytes are
+    # scanned (or skipped), look at every third byte, etc.. When a match
+    # is found, immediately go back to looking at every byte. This is a
+    # small loss (~5% performance, ~0.1% density) for compressible data
+    # due to more bookkeeping, but for non-compressible data (such as
+    # JPEG) it's a huge win since the compressor quickly "realizes" the
+    # data is incompressible and doesn't bother looking for matches
+    # everywhere.
+    #
+    # The "skip" variable keeps track of how many bytes there are since
+    # the last match; dividing it by 32 (ie. right-shifting by five) gives
+    # the number of bytes to move ahead for each iteration.
+    var skip = 32
+
+    var nextS = s
+    var candidate = 0
+    while true:
+      s = nextS
+      let bytesBetweenHashLookups = skip shr 5
+      nextS = s + bytesBetweenHashLookups
+      inc(skip, bytesBetweenHashLookups)
+      if nextS > sLimit:
+        emitRemainder()
+
+      candidate = int(table[nextHash and tableMask])
+      table[nextHash and tableMask] = uint16(s)
+      nextHash = hash(fromBytesLE(uint32, src.toOpenArray(nextS, nextS+3)), shift.uint32)
+      if fromBytesLE(uint32, src.toOpenArray(s, s+3)) == fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
+        break
+
+    # A 4-byte match has been found. We'll later see if more than 4 bytes
+    # match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+    # them as literal bytes.
+    d += emitLiteral(dst, d, src.toOpenArray(nextEmit, s-1))
+
+    # Call emitCopy, and then see if another emitCopy could be our next
+    # move. Repeat until we find no match for the input immediately after
+    # what was consumed by the last emitCopy call.
+    #
+    # If we exit this loop normally then we need to call emitLiteral next,
+    # though we don't yet know how big the literal will be. We handle that
+    # by proceeding to the next iteration of the main loop. We also can
+    # exit this loop via goto if we get close to exhausting the input.
+    while true:
+      # Invariant: we have a 4-byte match at s, and no need to emit any
+      # literal bytes prior to s.
+      var base = s
+
+      # Extend the 4-byte match as long as possible.
+      #
+      # This is an inlined version of:
+      #  s = extendMatch(src, candidate+4, s+4)
+      inc(s, 4)
+      var i = candidate + 4
+      while s < src.len and src[i] == src[s]:
+        inc i
+        inc s
+
+      d += emitCopy(dst, d, base-candidate, s-base)
+      nextEmit = s
+      if s >= sLimit:
+        emitRemainder()
+
+      # We could immediately start working at s now, but to improve
+      # compression we first update the hash table at s-1 and at s. If
+      # another emitCopy is not our next move, also calculate nextHash
+      # at s+1. At least on ARCH=amd64, these three hash calculations
+      # are faster as one load64 call (with some shifts) instead of
+      # three load32 calls.
+      let x = fromBytesLE(uint64, src.toOpenArray(s-1, src.len-1))
+      let prevHash = hash(uint32(x shr 0), shift.uint32)
+      table[prevHash and tableMask] = uint16(s - 1)
+      let currHash = hash(uint32(x shr 8), shift.uint32)
+      candidate = int(table[currHash and tableMask])
+      table[currHash and tableMask] = uint16(s)
+      if uint32(x shr 8) != fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
+        nextHash = hash(uint32(x shr 16), shift.uint32)
+        inc s
+        break
+
+  d - offset

--- a/snappy/types.nim
+++ b/snappy/types.nim
@@ -9,44 +9,5 @@ type
 
   InputTooLarge* = object of SnappyEncodingError
 
-const
-  maxUncompressedLen* = 0xffffffff'u32
-  maxBlockSize* = 65536
-
-template raiseInputTooLarge* =
+func raiseInputTooLarge*() {.noreturn, raises: [Defect, InputTooLarge].} =
   raise newException(InputTooLarge, "Input too large to be compressed with Snappy")
-
-proc checkInputLen*(len: Natural): uint32 =
-  when sizeof(int) == 8:
-    if len > 0xffffffff:
-      raiseInputTooLarge()
-  uint32(len)
-
-# maxCompressedLen returns the maximum length of a snappy block, given its
-# uncompressed length.
-#
-# It will return a zero value if srcLen is too large to encode.
-func maxCompressedLen*(srcLen: uint32): uint64 =
-  # Compressed data can be defined as:
-  #    compressed := item* literal*
-  #    item       := literal* copy
-  #
-  # The trailing literal sequence has a space blowup of at most 62/60
-  # since a literal of length 60 needs one tag byte + one extra byte
-  # for length information.
-  #
-  # Item blowup is trickier to measure. Suppose the "copy" op copies
-  # 4 bytes of data. Because of a special check in the encoding code,
-  # we produce a 4-byte copy only if the offset is < 65536. Therefore
-  # the copy op takes 3 bytes to encode, and this type of item leads
-  # to at most the 62/60 blowup for representing literals.
-  #
-  # Suppose the "copy" op copies 5 bytes of data. If the offset is big
-  # enough, it will take 5 bytes to encode the copy op. Therefore the
-  # worst case here is a one-byte literal followed by a five-byte copy.
-  # That is, 6 bytes of input turn into 7 bytes of "compressed" data.
-  #
-  # This last factor dominates the blowup, so the final estimate is:
-  let n = srcLen.uint64
-  32'u64 + n + n div 6'u64
-

--- a/tests/openarrays_snappy.nim
+++ b/tests/openarrays_snappy.nim
@@ -1,386 +1,6 @@
-import stew/[endians2, leb128, arrayops]
-
-const
-  tagLiteral* = 0x00
-  tagCopy1*   = 0x01
-  tagCopy2*   = 0x02
-  tagCopy4*   = 0x03
-
-  inputMargin = 16 - 1
-
-# emitLiteral writes a literal chunk and returns the number of bytes written.
-#
-# It assumes that:
-#  dst is long enough to hold the encoded bytes
-#  1 <= len(lit) and len(lit) <= 65536
-func emitLiteral(dst: var openArray[byte], d: int, lit: openArray[byte]): int =
-  var
-    i = d
-    n = lit.len-1
-
-  if n < 60:
-    dst[i + 0] = (byte(n) shl 2) or tagLiteral
-    inc(i)
-  elif n < (1 shl 8):
-    dst[i + 0] = (60 shl 2) or tagLiteral
-    dst[i + 1] = byte(n)
-    inc(i, 2)
-  else:
-    dst[i + 0] = (61 shl 2) or tagLiteral
-    dst[i + 1] = byte(n and 0xFF)
-    dst[i + 2] = byte((n shr 8) and 0xFF)
-    inc(i, 3)
-
-  dst[i..<i+lit.len] = lit
-  result = i + lit.len - d
-
-
-# emitCopy writes a copy chunk and returns the number of bytes written.
-#
-# It assumes that:
-#  dst is long enough to hold the encoded bytes
-#  1 <= offset and offset <= 65535
-#  4 <= length and length <= 65535
-func emitCopy(dst: var openArray[byte], d, offset, length: int): int =
-  var
-    i = d
-    length = length
-  # The maximum length for a single tagCopy1 or tagCopy2 op is 64 bytes. The
-  # threshold for this loop is a little higher (at 68 = 64 + 4), and the
-  # length emitted down below is is a little lower (at 60 = 64 - 4), because
-  # it's shorter to encode a length 67 copy as a length 60 tagCopy2 followed
-  # by a length 7 tagCopy1 (which encodes as 3+2 bytes) than to encode it as
-  # a length 64 tagCopy2 followed by a length 3 tagCopy2 (which encodes as
-  # 3+3 bytes). The magic 4 in the 64±4 is because the minimum length for a
-  # tagCopy1 op is 4 bytes, which is why a length 3 copy has to be an
-  # encodes-as-3-bytes tagCopy2 instead of an encodes-as-2-bytes tagCopy1.
-  while length >= 68:
-    # Emit a length 64 copy, encoded as 3 bytes.
-    dst[i+0] = (63 shl 2) or tagCopy2
-    dst[i+1] = byte(offset and 0xFF)
-    dst[i+2] = byte((offset shr 8) and 0xFF)
-    inc(i, 3)
-    dec(length, 64)
-
-  if length > 64:
-    # Emit a length 60 copy, encoded as 3 bytes.
-    dst[i+0] = (59 shl 2) or tagCopy2
-    dst[i+1] = byte(offset and 0xFF)
-    dst[i+2] = byte((offset shr 8) and 0xFF)
-    inc(i, 3)
-    dec(length, 60)
-
-  if (length >= 12) or (offset >= 2048):
-    # Emit the remaining copy, encoded as 3 bytes.
-    dst[i+0] = (byte(length-1) shl 2) or tagCopy2
-    dst[i+1] = byte(offset and 0xFF)
-    dst[i+2] = byte((offset shr 8) and 0xFF)
-    return i + 3 - d
-
-  # Emit the remaining copy, encoded as 2 bytes.
-  dst[i+0] = byte((((offset shr 8) shl 5) or ((length-4) shl 2) or tagCopy1) and 0xFF)
-  dst[i+1] = byte(offset and 0xFF)
-  result = i + 2 - d
-
-when false:
-  # extendMatch returns the largest k such that k <= len(src) and that
-  # src[i:i+k-j] and src[j:k] have the same contents.
-  #
-  # It assumes that:
-  #  0 <= i and i < j and j <= len(src)
-  func extendMatch(src: openArray[byte], i, j: int): int =
-    var
-      i = i
-      j = j
-    while j < src.len and src[i] == src[j]:
-      inc i
-      inc j
-    result = j
-
-func hash(u, shift: uint32): uint32 =
-  result = (u * 0x1e35a7bd) shr shift
-
-# encodeBlock encodes a non-empty src to a guaranteed-large-enough dst. It
-# assumes that the varint-encoded length of the decompressed bytes has already
-# been written.
-#
-# It also assumes that:
-#  len(dst) >= MaxEncodedLen(len(src)) and
-#  minNonLiteralBlockSize <= len(src) and len(src) <= maxBlockSize
-func encodeBlock*(dst: var openArray[byte], offset: int, src: openArray[byte]): int =
-  # Initialize the hash table. Its size ranges from 1shl8 to 1shl14 inclusive.
-  # The table element type is uint16, as s < sLimit and sLimit < len(src)
-  # and len(src) <= maxBlockSize and maxBlockSize == 65536.
-  const
-    maxTableSize = 1 shl 14
-    # tableMask is redundant, but helps the compiler eliminate bounds
-    # checks.
-    tableMask = maxTableSize - 1
-
-  var
-    shift = 32 - 8
-    tableSize = 1 shl 8
-
-  while tableSize < maxTableSize and tableSize < src.len:
-    tableSize = tableSize * 2
-    dec shift
-
-  # In Nim, all array elements are zero-initialized, so there is no advantage
-  # to a smaller tableSize per se. However, it matches the C++ algorithm,
-  # and in the asm versions of this code, we can get away with zeroing only
-  # the first tableSize elements.
-  var table: array[maxTableSize, uint16]
-
-  # sLimit is when to stop looking for offset/length copies. The inputMargin
-  # lets us use a fast path for emitLiteral in the main loop, while we are
-  # looking for copies.
-  var sLimit = src.len - inputMargin
-  # nextEmit is where in src the next emitLiteral should start from.
-  var nextEmit = 0
-
-  # The encoded form must start with a literal, as there are no previous
-  # bytes to copy, so we start looking for hash matches at s == 1.
-  var s = 1
-  var nextHash = hash(fromBytesLE(uint32, src.toOpenArray(s, s+3)), shift.uint32)
-  var d = offset
-
-  template emitRemainder(): untyped =
-    if nextEmit < src.len:
-      d += emitLiteral(dst, d, src.toOpenArray(nextEmit, src.high))
-    return d - offset
-
-  while true:
-    # Copied from the C++ snappy implementation:
-    #
-    # Heuristic match skipping: If 32 bytes are scanned with no matches
-    # found, start looking only at every other byte. If 32 more bytes are
-    # scanned (or skipped), look at every third byte, etc.. When a match
-    # is found, immediately go back to looking at every byte. This is a
-    # small loss (~5% performance, ~0.1% density) for compressible data
-    # due to more bookkeeping, but for non-compressible data (such as
-    # JPEG) it's a huge win since the compressor quickly "realizes" the
-    # data is incompressible and doesn't bother looking for matches
-    # everywhere.
-    #
-    # The "skip" variable keeps track of how many bytes there are since
-    # the last match; dividing it by 32 (ie. right-shifting by five) gives
-    # the number of bytes to move ahead for each iteration.
-    var skip = 32
-
-    var nextS = s
-    var candidate = 0
-    while true:
-      s = nextS
-      let bytesBetweenHashLookups = skip shr 5
-      nextS = s + bytesBetweenHashLookups
-      inc(skip, bytesBetweenHashLookups)
-      if nextS > sLimit:
-        emitRemainder()
-
-      candidate = int(table[nextHash and tableMask])
-      table[nextHash and tableMask] = uint16(s)
-      nextHash = hash(fromBytesLE(uint32, src.toOpenArray(nextS, nextS+3)), shift.uint32)
-      if fromBytesLE(uint32, src.toOpenArray(s, s+3)) == fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
-        break
-
-    # A 4-byte match has been found. We'll later see if more than 4 bytes
-    # match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
-    # them as literal bytes.
-    d += emitLiteral(dst, d, src.toOpenArray(nextEmit, s-1))
-
-    # Call emitCopy, and then see if another emitCopy could be our next
-    # move. Repeat until we find no match for the input immediately after
-    # what was consumed by the last emitCopy call.
-    #
-    # If we exit this loop normally then we need to call emitLiteral next,
-    # though we don't yet know how big the literal will be. We handle that
-    # by proceeding to the next iteration of the main loop. We also can
-    # exit this loop via goto if we get close to exhausting the input.
-    while true:
-      # Invariant: we have a 4-byte match at s, and no need to emit any
-      # literal bytes prior to s.
-      var base = s
-
-      # Extend the 4-byte match as long as possible.
-      #
-      # This is an inlined version of:
-      #  s = extendMatch(src, candidate+4, s+4)
-      inc(s, 4)
-      var i = candidate + 4
-      while s < src.len and src[i] == src[s]:
-        inc i
-        inc s
-
-      d += emitCopy(dst, d, base-candidate, s-base)
-      nextEmit = s
-      if s >= sLimit:
-        emitRemainder()
-
-      # We could immediately start working at s now, but to improve
-      # compression we first update the hash table at s-1 and at s. If
-      # another emitCopy is not our next move, also calculate nextHash
-      # at s+1. At least on ARCH=amd64, these three hash calculations
-      # are faster as one load64 call (with some shifts) instead of
-      # three load32 calls.
-      let x = fromBytesLE(uint64, src.toOpenArray(s-1, src.len-1))
-      let prevHash = hash(uint32(x shr 0), shift.uint32)
-      table[prevHash and tableMask] = uint16(s - 1)
-      let currHash = hash(uint32(x shr 8), shift.uint32)
-      candidate = int(table[currHash and tableMask])
-      table[currHash and tableMask] = uint16(s)
-      if uint32(x shr 8) != fromBytesLE(uint32, src.toOpenArray(candidate, candidate+3)):
-        nextHash = hash(uint32(x shr 16), shift.uint32)
-        inc s
-        break
-  result = d - offset
-
-const
-  decodeErrCodeCorrupt = 1
-  decodeErrCodeUnsupportedLiteralLength = 2
-
-func decode(dst: var openArray[byte], src: openArray[byte]): int =
-  var
-    d = 0
-    s = 0
-    offset = 0
-    length = 0
-
-  while s < src.len:
-    let tag = src[s] and 0x03
-    case tag
-    of tagLiteral:
-      var x = int(src[s]) shr 2
-      if x < 60:
-        inc s
-      elif x == 60:
-        inc(s, 2)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-1])
-      elif x == 61:
-        inc(s, 3)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-2]) or (int(src[s-1]) shl 8)
-      elif x == 62:
-        inc(s, 4)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-3]) or (int(src[s-2]) shl 8) or (int(src[s-1]) shl 16)
-      elif x == 63:
-        inc(s, 5)
-        if s > src.len:
-          return decodeErrCodeCorrupt
-        x = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
-      length = x + 1
-      if length <= 0:
-        return decodeErrCodeUnsupportedLiteralLength
-
-      if (length > (dst.len-d)) or (length > (src.len-s)):
-        return decodeErrCodeCorrupt
-
-      dst[d..<d+length] = src.toOpenArray(s, s+length-1)
-      inc(d, length)
-      inc(s, length)
-      continue
-
-    of tagCopy1:
-      inc(s, 2)
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 4 + ((int(src[s-2]) shr 2) and 0x07)
-      offset = ((int(src[s-2]) and 0xe0) shl 3) or int(src[s-1])
-
-    of tagCopy2:
-      s += 3
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 1 + (int(src[s-3]) shr 2)
-      offset = int(src[s-2]) or (int(src[s-1]) shl 8)
-
-    of tagCopy4:
-      s += 5
-      if s > src.len:
-        return decodeErrCodeCorrupt
-      length = 1 + (int(src[s-5]) shr 2)
-      offset = int(src[s-4]) or (int(src[s-3]) shl 8) or (int(src[s-2]) shl 16) or (int(src[s-1]) shl 24)
-
-    else: discard
-
-    if offset <= 0 or d < offset or (length > (dst.len-d)):
-      return decodeErrCodeCorrupt
-
-    # Copy from an earlier sub-slice of dst to a later sub-slice. Unlike
-    # the built-in copy function, this byte-by-byte copy always runs
-    # forwards, even if the slices overlap. Conceptually, this is:
-    #
-    # d += forwardCopy(dst[d:d+length], dst[d-offset:])
-    let stop = d + length
-    while d != stop:
-      dst[d] = dst[d-offset]
-      inc d
-
-  if d != dst.len:
-    return decodeErrCodeCorrupt
-  return 0
-
-# MaxEncodedLen returns the maximum length of a snappy block, given its
-# uncompressed length.
-#
-# It will return a zero value if srcLen is too large to encode.
-func maxEncodedLen(srcLen: int): int =
-  var n = uint64(srcLen)
-  if n > 0xffffffff'u64:
-    return 0
-
-  # Compressed data can be defined as:
-  #    compressed := item* literal*
-  #    item       := literal* copy
-  #
-  # The trailing literal sequence has a space blowup of at most 62/60
-  # since a literal of length 60 needs one tag byte + one extra byte
-  # for length information.
-  #
-  # Item blowup is trickier to measure. Suppose the "copy" op copies
-  # 4 bytes of data. Because of a special check in the encoding code,
-  # we produce a 4-byte copy only if the offset is < 65536. Therefore
-  # the copy op takes 3 bytes to encode, and this type of item leads
-  # to at most the 62/60 blowup for representing literals.
-  #
-  # Suppose the "copy" op copies 5 bytes of data. If the offset is big
-  # enough, it will take 5 bytes to encode the copy op. Therefore the
-  # worst case here is a one-byte literal followed by a five-byte copy.
-  # That is, 6 bytes of input turn into 7 bytes of "compressed" data.
-  #
-  # This last factor dominates the blowup, so the final estimate is:
-  n = 32'u64 + n + n div 6'u64
-  if n > 0xffffffff'u64:
-    return 0
-
-  result = int(n)
-
-const
-  maxBlockSize = 65536
-
-# minNonLiteralBlockSize is the minimum size of the input to encodeBlock that
-# could be encoded with a copy tag. This is the minimum with respect to the
-# algorithm used by encodeBlock, not a minimum enforced by the file format.
-#
-# The encoded output must start with at least a 1 byte literal, as there are
-# no previous bytes to copy. A minimal (1 byte) copy after that, generated
-# from an emitCopy call in encodeBlock's main loop, would require at least
-# another inputMargin bytes, for the reason above: we want any emitLiteral
-# calls inside encodeBlock's main loop to use the fast path if possible, which
-# requires being able to overrun by inputMargin bytes. Thus,
-# minNonLiteralBlockSize equals 1 + 1 + inputMargin.
-#
-# The C++ code doesn't use this exact threshold, but it could, as discussed at
-# https:#groups.google.com/d/topic/snappy-compression/oGbhsdIJSJ8/discussion
-# The difference between Nim (2+inputMargin) and C++ (inputMargin) is purely an
-# optimization. It should not affect the encoded form. This is tested by
-# TestSameEncodingAsCppShortCopies.
-const
-  minNonLiteralBlockSize = 1 + 1 + inputMargin
+import
+  stew/[leb128],
+  ../snappy/[codec, decoder, encoder_oa]
 
 # Encode returns the encoded form of src. The returned slice may be a sub-
 # slice of dst if dst was large enough to hold the entire encoded block.
@@ -388,50 +8,52 @@ const
 #
 # The dst and src must not overlap. It is valid to pass a nil dst.
 func encode*(src: openArray[byte]): seq[byte] =
-  let n = maxEncodedLen(src.len)
-  if n == 0: return
-  var dst = newSeq[byte](n)
+  let
+    lenU32 = checkInputLen(src.len).valueOr:
+      return
+    maxCompressed = maxCompressedLen(lenU32).valueOr:
+      return
+
+  # TODO https://github.com/nim-lang/Nim/issues/19357
+  result.setLen(maxCompressed)
 
   # The block starts with the varint-encoded length of the decompressed bytes.
   let
-    leb128 = uint32(src.len).toBytes(Leb128)
+    leb128 = lenU32.toBytes(Leb128)
 
   var
     p = 0
     d = int(leb128.len)
     len = src.len
 
-  dst[0..<d] = leb128.toOpenArray()
+  result[0..<d] = leb128.toOpenArray()
 
   while len > 0:
-    var blockSize = len
-    if blockSize > maxBlockSize:
-      blockSize = maxBlockSize
+    let blockSize = min(len, maxBlockSize.int)
 
     if blockSize < minNonLiteralBlockSize:
-      d += emitLiteral(dst, d, src.toOpenArray(p, p+blockSize-1))
+      d += emitLiteral(result, d, src.toOpenArray(p, p+blockSize-1))
     else:
-      d += encodeBlock(dst, d, src.toOpenArray(p, p+blockSize-1))
+      d += encodeBlock(result, d, src.toOpenArray(p, p+blockSize-1))
 
     inc(p, blockSize)
     dec(len, blockSize)
 
-  dst.setLen(d)
-  shallowCopy(result, dst)
+  result.setLen(d)
 
 # decodedLen returns the length of the decoded block and the number of bytes
 # that the length header occupied.
 func decode*(src: openArray[byte]): seq[byte] =
-  let (len, bytesRead) = fromBytes(uint64, src, Leb128)
-  if bytesRead <= 0 or len > 0xffffffff'u64:
+  let (lenU32, bytesRead) = fromBytes(uint32, src, Leb128)
+  if bytesRead <= 0:
     return
 
   const wordSize = sizeof(uint) * 8
-  if (wordSize == 32) and (len > 0x7fffffff'u64):
+  if (wordSize == 32) and (lenU32 > 0x7fffffff'u64):
     return
 
-  if int(len) > 0:
-    result = newSeq[byte](len)
+  if lenU32 > 0:
+    result.setLen(lenU32.int) # TODO protect against decompression bombs
     let errCode = decode(result, src.toOpenArray(bytesRead, src.len-1))
     if errCode != 0: result = @[]
 

--- a/tests/test_codec.nim
+++ b/tests/test_codec.nim
@@ -1,8 +1,10 @@
 {.used.}
 
 import
-  os, unittest, terminal, strutils,
+  std/[os, strutils],
+  unittest2,
   faststreams,
+  ../snappy/codec,
   snappy, randgen, openarrays_snappy, nimstreams_snappy, cpp_snappy
 
 include system/timers
@@ -111,7 +113,7 @@ suite "snappy":
       inc(i, 23)
 
     for m in 1 .. 5:
-      for i in m * maxBlockSize - 5 .. m * maxBlockSize + 5:
+      for i in m * maxBlockSize.int - 5 .. m * maxBlockSize.int + 5:
         var buf = newSeq[byte](i)
         for j in 0..<buf.len:
           buf[j] = byte((j mod 10) + int('a'))

--- a/tests/test_framing_format.nim
+++ b/tests/test_framing_format.nim
@@ -1,7 +1,8 @@
 {.used.}
 
 import
-  unittest, os,
+  std/os,
+  unittest2,
   faststreams,
   ../snappy/framing
 
@@ -39,30 +40,28 @@ template check_roundtrip(source) =
     else:
       check true
 
-proc main() =
-  suite "framing":
-    setup:
-      let
-        compDir {.used.} = getAppDir() & DirSep & "stream_compressed" & DirSep
-        uncompDir {.used.} = getAppDir() & DirSep & "data" & DirSep
+suite "framing":
+  setup:
+    let
+      compDir {.used.} = getAppDir() & DirSep & "stream_compressed" & DirSep
+      uncompDir {.used.} = getAppDir() & DirSep & "data" & DirSep
 
-    check_uncompress("alice29.txt.sz-32k", "alice29.txt")
-    check_uncompress("alice29.txt.sz-64k", "alice29.txt")
-    check_uncompress("house.jpg.sz", "house.jpg")
+  check_uncompress("alice29.txt.sz-32k", "alice29.txt")
+  check_uncompress("alice29.txt.sz-64k", "alice29.txt")
+  check_uncompress("house.jpg.sz", "house.jpg")
 
-    check_roundtrip("alice29.txt")
-    check_roundtrip("house.jpg")
-    check_roundtrip("html")
-    check_roundtrip("urls.10K")
-    check_roundtrip("fireworks.jpeg")
+  check_roundtrip("alice29.txt")
+  check_roundtrip("house.jpg")
+  check_roundtrip("html")
+  check_roundtrip("urls.10K")
+  check_roundtrip("fireworks.jpeg")
 
-    check_roundtrip("paper-100k.pdf")
+  check_roundtrip("paper-100k.pdf")
 
-    check_roundtrip("html_x_4")
-    check_roundtrip("asyoulik.txt")
-    check_roundtrip("lcet10.txt")
-    check_roundtrip("plrabn12.txt")
-    check_roundtrip("geo.protodata")
-    check_roundtrip("kppkn.gtb")
-    check_roundtrip("Mark.Twain-Tom.Sawyer.txt")
-main()
+  check_roundtrip("html_x_4")
+  check_roundtrip("asyoulik.txt")
+  check_roundtrip("lcet10.txt")
+  check_roundtrip("plrabn12.txt")
+  check_roundtrip("geo.protodata")
+  check_roundtrip("kppkn.gtb")
+  check_roundtrip("Mark.Twain-Tom.Sawyer.txt")

--- a/tests/test_invalid_data.nim
+++ b/tests/test_invalid_data.nim
@@ -1,6 +1,8 @@
 {.used.}
 
-import os, faststreams/inputs, ../snappy/framing
+import
+  unittest2,
+  faststreams/inputs, ../snappy/framing
 
 proc parseInvalidInput(payload: openArray[byte]): bool =
   try:
@@ -9,9 +11,6 @@ proc parseInvalidInput(payload: openArray[byte]): bool =
   except SnappyError:
     result = true
 
-proc main() =
-  for x in walkDirRec("tests" / "invalidInput"):
-    let z = readFile(x)
-    doAssert parseInvalidInput(z.toOpenArrayByte(0, z.len-1))
-
-main()
+suite "invalid data":
+  test "invalid header":
+    check parseInvalidInput([byte 3, 2, 1, 0])


### PR DESCRIPTION
The snappy codebase is a mess with competing implementations,
nonsensical code duplication and no real direction due to a partially
implemented faststreams migration.

This PR makes it slightly less of a mess, but make no mistake, it's
still a mess - the difference being that there are a few more signposts
along the way in terms of module organisation, and a little less mess as
the line count of the PR discloses.

Performance remains poor - ~3x slower than C++ - but at least there's
less code to look at :)