### PR TITLE
allow skipping crc32 integrity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ master
 # Fuzzer-generated files
 crash-*
 
+build/

--- a/snappy/codec.nim
+++ b/snappy/codec.nim
@@ -196,7 +196,7 @@ func uncompressedLenFramed*(input: openArray[byte]): Opt[uint64] =
       else: 0'u32 # Reserved skippable (for example framing format header)
 
     if uncompressed > maxUncompressedFrameDataLen:
-      return # Uncomnpressed data has limits (for the known chunk types)
+      return # Uncompressed data has limits (for the known chunk types)
 
     expected += uncompressed
     read += dataLen


### PR DESCRIPTION
Some data is already protected by stronger checks - crc32 on the other hand significantly slows down framed reading - ie 2.5x slower:

```
118.853 / 41.781, 129.115 /  0.000, 188.438 /  0.000,  90.565 / 44.371,           50,    115613038, state-6800000-488b7150-d613b584.ssz
186.600 / 97.202, 191.935 /123.325,   0.000 /  0.000,   0.000 /  0.000,           50,    115613038, state-6800000-488b7150-d613b584.ssz(framed)
```

The difference between unframed and framed decoding is the CRC32 check - it takes ~50ms on a decent laptop for a 110mb file.