### PR TITLE
fix indexdefect on invalid framed data

### DIFF
--- a/snappy/codec.nim
+++ b/snappy/codec.nim
@@ -189,9 +189,14 @@ func uncompressedLenFramed*(input: openArray[byte]): Opt[uint64] =
 
     let uncompressed =
       if id == chunkCompressed:
+        if dataLen < 4: # At least CRC32
+          return
         uncompressedLen(input.toOpenArray(read + 4, read + dataLen - 1)).valueOr:
           return
-      elif id == chunkUncompressed: uint32(dataLen - 4)
+      elif id == chunkUncompressed:
+        if dataLen < 4: # At least CRC32
+          return
+        uint32(dataLen - 4)
       elif id < 0x80: return # Reserved unskippable chunk
       else: 0'u32 # Reserved skippable (for example framing format header)
 

--- a/tests/fuzzing/fuzz_block_format.nim
+++ b/tests/fuzzing/fuzz_block_format.nim
@@ -1,64 +1,33 @@
 import
   testutils/fuzzing,
-  ../../snappy
+  stew/ptrops,
+  ../../snappy, ../cpp_snappy
 
 {.push raises: [].}
 
-{.passl: "-lsnappy".}
-
-proc snappy_compress(input: cstring, input_length: csize, compressed: cstring, compressed_length: var csize): cint {.importc, cdecl.}
-proc snappy_uncompress(compressed: cstring, compressed_length: csize, uncompressed: cstring, uncompressed_length: var csize): cint {.importc, cdecl.}
-proc snappy_max_compressed_length(source_length: csize): csize {.importc, cdecl.}
-proc snappy_uncompressed_length(compressed: cstring, compressed_length: csize, res: var csize): cint {.importc, cdecl.}
-
-proc startsWith(lhs, rhs: openarray[byte]): bool =
-  if lhs.len < rhs.len:
-    return false
-
-  equalMem(unsafeAddr lhs[0], unsafeAddr rhs[0], rhs.len)
-
 test:
-  block:
-    if payload.len == 0:
-      break
-    let decoded = snappy.decode(payload, 128*1024*1024)
-    if decoded.len > 0:
-      let encoded = snappy.encode(decoded)
-      if not payload.startsWith(encoded):
-        var cppDecompressedLen: csize
-        let payload = @payload
-        if snappy_uncompressed_length(cast[cstring](unsafeAddr payload[0]),
-                                      payload.len.csize, cppDecompressedLen) == 0:
-          var cppDecompressed = newSeq[byte](cppDecompressedLen)
-          if snappy_uncompress(cast[cstring](unsafeAddr payload[0]), payload.len.csize,
-                                cast[cstring](addr cppDecompressed[0]), cppDecompressedLen) == 0:
-            if cppDecompressed == decoded:
-              discard
-              # echo "C++ decompression matches ours"
-            else:
-              echo "C++ decompression doesn't match ours"
+  var cppDecompressedLen: csize_t
 
-            var cppCompressedLen = snappy_max_compressed_length(cppDecompressed.len.csize)
-            var cppCompressed = newSeq[byte](cppCompressedLen)
-            if snappy_compress(cast[cstring](addr cppDecompressed[0]), cppDecompressed.len,
-                                cast[cstring](addr cppCompressed[0]), cppCompressedLen) == 0:
-              cppCompressed.setLen cppCompressedLen
-              if payload.startsWith(cppCompressed):
-                echo "C++ result matches original payload"
-              elif cppCompressed == encoded:
-                break
-                # echo "C++ result matches ours"
-              else:
-                echo "C++ result differs both from payload and ours"
-            else:
-              echo "C++ failed to compress back the payload"
-          else:
-            echo "C++ failed to decompress the payload"
-        else:
-          echo "C++ failed to obtain the payload decompressed length++"
+  let
+    lenRes =
+      snappy_uncompressed_length(
+        cast[cstring](baseAddr payload), payload.len.csize_t,
+        cppDecompressedLen)
 
-        echo "encoded len ", encoded.len
-        # echo encoded
-        echo "orig payload len ", payload.len
-        # echo payload
-        doAssert false
+    decoded = snappy.decode(payload, 128*1024*1024)
+  doAssert decoded.len == 0 or lenRes == 0 and decoded.len == cppDecompressedLen.int
+
+  if decoded.len > 0:
+    var cppDecompressed = newSeq[byte](cppDecompressedLen)
+    doAssert snappy_uncompress(
+      cast[cstring](baseAddr payload), payload.len.csize_t,
+      cast[ptr cchar](baseAddr cppDecompressed), cppDecompressedLen) == 0
+
+    doAssert cppDecompressed == decoded, "decompression should match between libraries"
+
+    let encoded = snappy.encode(decoded)
+    doAssert snappy_uncompress(
+      cast[cstring](baseAddr encoded), encoded.len.csize_t,
+      cast[ptr cchar](baseAddr cppDecompressed), cppDecompressedLen) == 0
+
+    doAssert cppDecompressed == decoded, "cpp should be able to decompress our compressed data"

--- a/tests/test_framed.nim
+++ b/tests/test_framed.nim
@@ -197,6 +197,7 @@ suite "framing":
 
   test "invalid header":
     checkInvalidFramed([byte 3, 2, 1, 0], 0)
+    checkInvalidFramed([byte 0, 0, 0, 0, 42], 0)
 
   test "overlong frame":
     let


### PR DESCRIPTION
* fix fuzzer so that it doesn't do exact comparison - this doesn't work any more because the implementations no longer match byte-for-byte - instead, we check that the libraries agree on valid/invalid and that C++ can decompress snappy-encoded data