### PR TITLE
Disable -Wuninitialized-const-pointer when building snappy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             cmake -E env CXXFLAGS="-w" cmake .. -G "MinGW Makefiles" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
             mingw32-make
           else
-            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter" ../
+            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized-const-pointer" ../
             make
           fi
           cp libsnappy.a ../../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           if [[ '${{ matrix.target.os }}' == 'windows' ]]; then
             cmake -E env CXXFLAGS="-w" cmake .. -G "MinGW Makefiles" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
             mingw32-make
-          elif [[ echo | gcc -dM -E - | grep -q '__clang__' ]]; then
+          elif echo | gcc -dM -E - | grep -q '__clang__'; then
             cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter -Wno-error=unknown-warning-option -Wno-error=uninitialized-const-pointer" ../
             make
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             cmake -E env CXXFLAGS="-w" cmake .. -G "MinGW Makefiles" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
             mingw32-make
           else
-            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter -Wno-error=uninitialized-const-pointer" ../
+            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter -Wno-error=unknown-warning-option -Wno-error=uninitialized-const-pointer" ../
             make
           fi
           cp libsnappy.a ../../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,11 @@ jobs:
           if [[ '${{ matrix.target.os }}' == 'windows' ]]; then
             cmake -E env CXXFLAGS="-w" cmake .. -G "MinGW Makefiles" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
             mingw32-make
-          else
+          elif [[ echo | gcc -dM -E - | grep -q '__clang__' ]]; then
             cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter -Wno-error=unknown-warning-option -Wno-error=uninitialized-const-pointer" ../
+            make
+          else
+            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter" ../
             make
           fi
           cp libsnappy.a ../../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
             cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter -Wno-error=unknown-warning-option -Wno-error=uninitialized-const-pointer" ../
             make
           else
-            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-error=unused-variable -Wno-error=unused-parameter" ../
+            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter" ../
             make
           fi
           cp libsnappy.a ../../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             cmake -E env CXXFLAGS="-w" cmake .. -G "MinGW Makefiles" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
             mingw32-make
           else
-            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized-const-pointer" ../
+            cmake -E env CC=gcc CXX=g++ cmake -D CMAKE_CXX_FLAGS="-Wno-unused-variable -Wno-unused-parameter -Wno-error=uninitialized-const-pointer" ../
             make
           fi
           cp libsnappy.a ../../


### PR DESCRIPTION
Newer macOS ships with compiler that emits -Wuninitialized-const-pointer when building upstream snappy.

- https://github.com/google/snappy/pull/245