### PR TITLE
Fix compile warnings

### DIFF
--- a/snappy.nim
+++ b/snappy.nim
@@ -3,7 +3,7 @@
 import
   stew/[arrayops, endians2, leb128],
   results,
-  ./snappy/[codec, decoder, encoder]
+  ./snappy/[codec, decoder, encoder, sequninit]
 
 export codec, results
 
@@ -77,7 +77,7 @@ func encode*(input: openArray[byte]): seq[byte] =
     maxCompressed = maxCompressedLen(input.len).valueOr:
       return
   # TODO https://github.com/nim-lang/Nim/issues/19357
-  result = newSeqUninitialized[byte](maxCompressed)
+  result = newSeqUninit[byte](maxCompressed)
   let written = compress(input, result).expect("we've checked lengths already")
   result.setLen(written)
 
@@ -122,7 +122,7 @@ func decode*(input: openArray[byte], maxSize = maxUncompressedLen): seq[byte] =
     return
 
   # TODO https://github.com/nim-lang/Nim/issues/19357
-  result = newSeqUninitialized[byte](int uncompressed)
+  result = newSeqUninit[byte](int uncompressed)
 
   if uncompress(input, result).isErr():
     result = @[] # Empty return on error
@@ -160,7 +160,7 @@ func encodeFramed*(input: openArray[byte]): seq[byte] =
     return
 
   # TODO https://github.com/nim-lang/Nim/issues/19357
-  result = newSeqUninitialized[byte](int maxCompressed)
+  result = newSeqUninit[byte](int maxCompressed)
   let
     written = compressFramed(input, result).expect("lengths checked")
 
@@ -253,8 +253,9 @@ func uncompressFramed*(
       if uncompressed > output.len - written:
         return ok((read - 4, written))
 
-      copyMem(addr output[written], unsafeAddr input[read + 4], uncompressed)
-      written += uncompressed
+      if uncompressed > 0:
+        copyMem(addr output[written], unsafeAddr input[read + 4], uncompressed)
+        written += uncompressed
 
     elif id < 0x80:
       return err(FrameError.unknownChunk) # Reserved unskippable chunk
@@ -284,7 +285,7 @@ func decodeFramed*(
     return
 
   # TODO https://github.com/nim-lang/Nim/issues/19357
-  result = newSeqUninitialized[byte](int uncompressed)
+  result = newSeqUninit[byte](int uncompressed)
 
   if uncompressFramed(input, result, checkIntegrity = checkIntegrity).isErr():
     result = @[] # Empty return on error

--- a/snappy.nimble
+++ b/snappy.nimble
@@ -26,10 +26,11 @@ let cfg =
   (if defined(linux):
     " --passC:" & sanitize & " --passL: " & sanitize
    else: "") &
-  " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
+  " --skipParentCfg --skipUserCfg"
 
 proc build(args, path: string) =
-  exec nimc & " " & lang & " " & cfg & " " & flags & " " & args & " " & path
+  exec nimc & " " & lang & " " & cfg &
+    " --outdir:build --nimcache:build/nimcache -f " & flags & " " & args & " " & path
 
 proc run(args, path: string) =
   build args & " --mm:refc -r", path

--- a/snappy/faststreams.nim
+++ b/snappy/faststreams.nim
@@ -3,7 +3,7 @@
 import
   stew/byteutils,
   pkg/faststreams/[inputs, multisync, outputs],
-  "."/[codec, encoder, exceptions],
+  "."/[codec, encoder, exceptions, sequninit],
   ../snappy
 
 export
@@ -38,7 +38,7 @@ proc compress*(input: InputStream, output: OutputStream) {.
   var
     # TODO instead of a temporary buffer, use `getWriteableBytes` once it
     #      works
-    tmp = newSeqUninitialized[byte](int maxCompressedBlockLen)
+    tmp = newSeqUninit[byte](int maxCompressedBlockLen)
 
   while input.readable(maxBlockLen.int):
     let written = encodeBlock(input.read(maxBlockLen.int), tmp)
@@ -67,7 +67,7 @@ proc compressFramed*(input: InputStream, output: OutputStream) {.
   output.write(framingHeader)
 
   var
-    tmp = newSeqUninitialized[byte](int maxCompressedFrameDataLen)
+    tmp = newSeqUninit[byte](int maxCompressedFrameDataLen)
 
   while input.readable(maxUncompressedFrameDataLen.int):
     let written = encodeFrame(input.read(maxUncompressedFrameDataLen.int), tmp)
@@ -95,7 +95,7 @@ proc uncompressFramed*(
   if input.read(framingHeader.len) != framingHeader:
     raise newException(MalformedSnappyData, "Invalid header value")
 
-  var tmp = newSeqUninitialized[byte](maxUncompressedFrameDataLen)
+  var tmp = newSeqUninit[byte](maxUncompressedFrameDataLen)
   while input.readable(4):
     let (id, dataLen) = decodeFrameHeader(input.read(4))
 

--- a/snappy/faststreams.nim
+++ b/snappy/faststreams.nim
@@ -3,7 +3,7 @@
 import
   stew/byteutils,
   pkg/faststreams/[inputs, multisync, outputs],
-  "."/[codec, encoder, exceptions, sequninit],
+  ./[codec, encoder, exceptions, sequninit],
   ../snappy
 
 export

--- a/snappy/sequninit.nim
+++ b/snappy/sequninit.nim
@@ -1,8 +1,6 @@
 {.push raises: [].}
 {.used.}
 
-when not declared(newSeqUninit):
-  # newSeqUninit template avoids deprecated errors
-  # for newSeqUninitialized in nim > 2.2
+when (NimMajor, NimMinor) < (2, 2):
   template newSeqUninit*[T: byte](len: Natural): seq[byte] =
     newSeqUninitialized[byte](len)

--- a/snappy/sequninit.nim
+++ b/snappy/sequninit.nim
@@ -1,0 +1,8 @@
+{.push raises: [].}
+{.used.}
+
+when not declared(newSeqUninit):
+  # newSeqUninit template avoids deprecated errors
+  # for newSeqUninitialized in nim > 2.2
+  template newSeqUninit*[T: byte](len: Natural): seq[byte] =
+    newSeqUninitialized[byte](len)

--- a/snappy/streams.nim
+++ b/snappy/streams.nim
@@ -2,7 +2,7 @@
 
 import
   std/streams,
-  "."/[codec, encoder, exceptions]
+  "."/[codec, encoder, exceptions, sequninit]
 
 export streams, exceptions
 
@@ -24,8 +24,8 @@ proc compress*(input: Stream, inputLen: int, output: Stream) {.
   output.writeData(unsafeAddr header.data[0], header.len)
 
   var
-    tmpIn = newSeqUninitialized[byte](int maxBlockLen)
-    tmpOut = newSeqUninitialized[byte](int maxCompressedBlockLen)
+    tmpIn = newSeqUninit[byte](int maxBlockLen)
+    tmpOut = newSeqUninit[byte](int maxCompressedBlockLen)
     read = 0
 
   while read < inputLen:

--- a/snappy/streams.nim
+++ b/snappy/streams.nim
@@ -2,7 +2,7 @@
 
 import
   std/streams,
-  "."/[codec, encoder, exceptions, sequninit]
+  ./[codec, encoder, exceptions, sequninit]
 
 export streams, exceptions
 

--- a/tests/benchmark.nim
+++ b/tests/benchmark.nim
@@ -3,7 +3,7 @@
 import
   stew/byteutils,
   os, strformat, stats, times,
-  snappy, cpp_snappy, ../snappy/[faststreams, streams]
+  snappy, cpp_snappy, ../snappy/[faststreams, streams, sequninit]
 
 const
   currentDir = currentSourcePath.parentDir
@@ -45,7 +45,7 @@ proc readSource(sourceName: string): seq[byte] =
   var f = open(sourceName, fmRead)
   if f.isNil: return
   let size = f.getFileSize()
-  result = newSeqUninitialized[byte](size)
+  result = newSeqUninit[byte](size)
   doAssert(size == f.readBytes(result, 0, size))
   f.close()
 

--- a/tests/cpp_snappy.nim
+++ b/tests/cpp_snappy.nim
@@ -1,4 +1,4 @@
-import std/os
+import std/os, ../snappy/sequninit
 
 const
   currentDir = currentSourcePath.parentDir
@@ -11,7 +11,7 @@ proc snappy_max_compressed_length*(source_length: csize_t): csize_t {.importc, c
 proc snappy_uncompressed_length*(compressed: cstring, compressed_length: csize_t, res: var csize_t): cint {.importc, cdecl.}
 
 proc encode*(input: openArray[byte]): seq[byte] =
-  result = newSeqUninitialized[byte](
+  result = newSeqUninit[byte](
     snappy_max_compressed_length(input.len.csize_t))
   var bytes = result.len.csize_t
   let res = if input.len() == 0:
@@ -37,7 +37,7 @@ proc decode*(input: openArray[byte]): seq[byte] =
   if bytes == 0:
     return
 
-  result = newSeqUninitialized[byte](bytes.int)
+  result = newSeqUninit[byte](bytes.int)
 
   if snappy_uncompress(
       cast[cstring](unsafeAddr input[0]), input.len().csize_t,

--- a/tests/test_framed.nim
+++ b/tests/test_framed.nim
@@ -4,7 +4,7 @@ import
   std/os, stew/byteutils,
   unittest2,
   ../snappy,
-  ../snappy/faststreams
+  ../snappy/[faststreams, sequninit]
 
 template check_uncompress(source, target: string) =
   test "uncompress " & source & " to " & target:
@@ -28,7 +28,7 @@ template check_uncompress(source, target: string) =
     check:
       uncompressedLenFramed(sourceData) == Opt[uint64].ok(expected.len.uint64)
 
-    var uncompressOut = newSeqUninitialized[byte](expected.len)
+    var uncompressOut = newSeqUninit[byte](expected.len)
     check:
       uncompressFramed(sourceData, uncompressOut).expect(
         "decompression worked") == (sourceData.len, expected.len)
@@ -81,7 +81,7 @@ template check_roundtrip(source) =
       check true
 
 proc checkInvalidFramed(payload: openArray[byte], uncompressedLen: int) =
-  var tmp = newSeqUninitialized[byte](uncompressedLen)
+  var tmp = newSeqUninit[byte](uncompressedLen)
   check:
     uncompressFramed(payload, tmp).isErr()
 
@@ -95,7 +95,7 @@ proc checkInvalidFramed(payload: openArray[byte], uncompressedLen: int) =
   check uncompressedLenFramed(payload).isNone
 
 proc checkValidFramed(payload: openArray[byte], expected: openArray[byte], checkIntegrity = true) =
-  var tmp = newSeqUninitialized[byte](expected.len)
+  var tmp = newSeqUninit[byte](expected.len)
   check:
     decodeFramed(payload, checkIntegrity = checkIntegrity) == expected
     uncompressFramed(payload, tmp, checkIntegrity = checkIntegrity).get() == (payload.len, expected.len)

--- a/tests/test_snappy.nim
+++ b/tests/test_snappy.nim
@@ -5,7 +5,7 @@ import
   std/[os, strutils],
   unittest2,
   ../snappy,
-  ../snappy/[faststreams, streams],
+  ../snappy/[faststreams, streams, sequninit],
   ./cpp_snappy, ./randgen
 
 include system/timers
@@ -22,7 +22,7 @@ proc readSource(sourceName: string): seq[byte] =
   var f = open(sourceName, fmRead)
   if f.isNil: return
   let size = f.getFileSize()
-  result = newSeqUninitialized[byte](size)
+  result = newSeqUninit[byte](size)
   doAssert(size == f.readBytes(result, 0, size))
   f.close()
 
@@ -72,10 +72,13 @@ proc roundTripRev(msg: string, source: openArray[byte]) =
   var
     decoded = snappy.decode(source)
     outputSize: csize_t = 0
-    ok = snappy_uncompressed_length(cast[cstring](source[0].unsafeAddr), source.len.csize_t, outputSize) == 0
+  let
+    ok = snappy_uncompressed_length(
+      cast[cstring](source[0].unsafeAddr), source.len.csize_t, outputSize) == 0
     cpp_decoded = cpp_snappy.decode(source)
 
   check:
+    ok
     decoded == cpp_decoded
 
 proc roundTripRev(msg: string, sourceName: string) =


### PR DESCRIPTION
Lots of newSeqUninitialized noise (renamed to newSeqUninit), some unused variables and empty copies.