### PR TITLE
Accept data with non-minimal length encoding

### DIFF
--- a/snappy/decoder.nim
+++ b/snappy/decoder.nim
@@ -52,13 +52,15 @@ func decodeAllTags*(
         continue
 
       if length >= 61:
-        let lenlen = length - 60 # 1-4
-        if (input.len - ip) < lenlen:
+        let
+          lenlen = length - 60 # 1-4
+          remainingInBytes = input.len - ip
+        if remainingInBytes < lenlen:
           return err(CodecError.invalidInput)
 
         # Length is actually in the little-endian bytes that follow
         let len32 =
-          if (input.len - ip) >= 4:
+          if remainingInBytes >= 4:
             # Decode 4 bytes then mask the excess (to avoid branching)
             const mask = [
               0'u32, 0xff'u32, 0xffff'u32, 0xffffff'u32, 0xffffffff'u32]

--- a/snappy/decoder.nim
+++ b/snappy/decoder.nim
@@ -52,17 +52,22 @@ func decodeAllTags*(
         continue
 
       if length >= 61:
-        if (input.len - ip) < 61:
-          # There must be at least 61 bytes, else we wouldn't be in this branch
+        let lenlen = length - 60 # 1-4
+        if (input.len - ip) < lenlen:
           return err(CodecError.invalidInput)
 
-        const mask = [0'u32, 0xff'u32, 0xffff'u32, 0xffffff'u32, 0xffffffff'u32]
-
         # Length is actually in the little-endian bytes that follow
-        # Decode 4 bytes then mask the excess (to avoid branching)
-        let
-          lenlen = length - 60 # 1-4
-          len32 = (load32(input, ip) and mask[lenlen]) + 1
+        let len32 =
+          if (input.len - ip) >= 4:
+            # Decode 4 bytes then mask the excess (to avoid branching)
+            const mask = [
+              0'u32, 0xff'u32, 0xffff'u32, 0xffffff'u32, 0xffffffff'u32]
+            (load32(input, ip) and mask[lenlen]) + 1
+          else:
+            var v: uint32
+            for i in 0 ..< lenlen:
+              v = v or (input[ip + i].uint32 shl (8 * i))
+            v + 1
 
         if len32 == 0: # wrap-around for 4-byte length
           return err(CodecError.invalidInput)

--- a/snappy/decoder.nim
+++ b/snappy/decoder.nim
@@ -64,8 +64,8 @@ func decodeAllTags*(
               0'u32, 0xff'u32, 0xffff'u32, 0xffffff'u32, 0xffffffff'u32]
             (load32(input, ip) and mask[lenlen]) + 1
           else:
-            var v: uint32
-            for i in 0 ..< lenlen:
+            var v = input[ip].uint32
+            for i in 1 ..< lenlen:
               v = v or (input[ip + i].uint32 shl (8 * i))
             v + 1
 

--- a/tests/test_snappy.nim
+++ b/tests/test_snappy.nim
@@ -220,6 +220,15 @@ suite "snappy":
 
     badData "\x11\x00\x00\xfc\xff\xff\xff\xff"
 
+  test "non-minimal literal length":
+    for data in [
+        "\x05\xF0\x04Hello",
+        "\x05\xF4\x04\x00Hello",
+        "\x05\xF8\x04\x00\x00Hello",
+        "\x05\xFC\x04\x00\x00\x00Hello",
+        "\x05\x10Hello"]:
+      check string.fromBytes(snappy.decode(data.toBytes)) == "Hello"
+
   test "random data":
     # Selected random inputs pulled from quickcheck failure witnesses.
     let random1 = [0'u8, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 1, 1,


### PR DESCRIPTION
google/snappy accepts data that does not use minimal length encoding, but nim-snappy rejects that. Accept suboptimally formed data for parity.