### PR TITLE
Avoid rejecting long padding section

### DIFF
--- a/snappy/faststreams.nim
+++ b/snappy/faststreams.nim
@@ -99,15 +99,16 @@ proc uncompressFramed*(
   while input.readable(4):
     let (id, dataLen) = decodeFrameHeader(input.read(4))
 
-    if dataLen.uint64 > maxCompressedFrameDataLen:
-      raise newException(MalformedSnappyData, "Invalid frame length: " & $dataLen)
-
     if not input.readable(dataLen):
       raise newException(UnexpectedEofError, "Failed to read the entire snappy frame")
 
     if id == chunkCompressed:
       if dataLen < 4:
         raise newException(MalformedSnappyData, "Frame size too low to contain CRC checksum")
+
+      if dataLen.uint64 > maxCompressedFrameDataLen:
+        raise newException(
+          MalformedSnappyData, "Invalid frame length: " & $dataLen)
 
       let
         crc = uint32.fromBytesLE input.read(4)

--- a/tests/test_framed.nim
+++ b/tests/test_framed.nim
@@ -217,3 +217,11 @@ suite "framing":
 
     checkInvalidFramed(framed, data.len)
     checkInvalidFramed(framedCompressed, data.len)
+
+  test "long padding chunk":
+    let
+      framed =
+        @framingHeader &
+        @[byte 0xfe, 0x00, 0x00, 0x02] & newSeq[byte](128 * 1024)
+
+    checkValidFramed(framed, @[])


### PR DESCRIPTION
The length check in faststreams applies the `maxCompressedFrameDataLen` also to non-compressed sections (e.g., padding chunks).