### PR TITLE
Reject invalid extra stream identifier chunks

### DIFF
--- a/snappy.nim
+++ b/snappy.nim
@@ -183,14 +183,17 @@ func uncompressFramed*(
   ## and a new output buffer.
   ##
   ## In case of errors, `output` may be partially overwritten with invalid data.
+  template validateFramingHeader(data: openArray[byte]) =
+    if data.len < framingHeader.len:
+      return err(FrameError.invalidInput)
+
+    if data.toOpenArray(0, framingHeader.len - 1) != framingHeader:
+      return err(FrameError.invalidInput)
+
   var
     read =
       if checkHeader:
-        if input.len < framingHeader.len:
-          return err(FrameError.invalidInput)
-
-        if input.toOpenArray(0, framingHeader.len - 1) != framingHeader:
-          return err(FrameError.invalidInput)
+        input.validateFramingHeader()
         framingHeader.len
       else:
         0
@@ -260,8 +263,16 @@ func uncompressFramed*(
     elif id < 0x80:
       return err(FrameError.unknownChunk) # Reserved unskippable chunk
 
+    elif id == chunkStream:
+      # The stream identifier chunk can come multiple times in the stream
+      # besides the first; if such a chunk shows up, it should simply be
+      # ignored, assuming it has the right length and contents. This allows for
+      # easy concatenation of compressed files without the need for re-framing.
+      # https://github.com/google/snappy/blob/main/framing_format.txt#L76-L79
+      input.toOpenArray(read - 4, input.high).validateFramingHeader()
+
     else:
-      discard # Reserved skippable chunk (for example framing format header)
+      discard # Reserved skippable chunk
 
     read += dataLen
 

--- a/snappy/faststreams.nim
+++ b/snappy/faststreams.nim
@@ -136,9 +136,20 @@ proc uncompressFramed*(
       # the spec says it is an error
       raise newException(MalformedSnappyData, "Invalid chunk type " & toHex([id]))
 
+    elif id == chunkStream:
+      # The stream identifier chunk can come multiple times in the stream
+      # besides the first; if such a chunk shows up, it should simply be
+      # ignored, assuming it has the right length and contents. This allows for
+      # easy concatenation of compressed files without the need for re-framing.
+      # https://github.com/google/snappy/blob/main/framing_format.txt#L76-L79
+      if dataLen != framingHeader.len - 4:
+        raise newException(MalformedSnappyData, "Invalid extra header length")
+
+      if input.read(dataLen) != framingHeader[4 .. framingHeader.high]:
+        raise newException(MalformedSnappyData, "Invalid extra header value")
+
     else:
-      # Reserved skippable chunks (chunk types 0x80-0xfe)
-      # including STREAM_HEADER (0xff) should be skipped
+      # Reserved skippable chunks (chunk types 0x80-0xfe) should be skipped
       input.advance dataLen
 
   if input.readable(1):

--- a/snappy/faststreams.nim
+++ b/snappy/faststreams.nim
@@ -145,7 +145,7 @@ proc uncompressFramed*(
       if dataLen != framingHeader.len - 4:
         raise newException(MalformedSnappyData, "Invalid extra header length")
 
-      if input.read(dataLen) != framingHeader[4 .. framingHeader.high]:
+      if input.read(dataLen) != framingHeader.toOpenArray(4, framingHeader.high):
         raise newException(MalformedSnappyData, "Invalid extra header value")
 
     else:

--- a/tests/test_framed.nim
+++ b/tests/test_framed.nim
@@ -92,7 +92,8 @@ proc checkInvalidFramed(payload: openArray[byte], uncompressedLen: int) =
     var output = memoryOutput()
     uncompressFramed(unsafeMemoryInput(payload), output)
 
-  check uncompressedLenFramed(payload).isNone
+  check uncompressedLenFramed(payload)
+    .get(uncompressedLen.uint64) == uncompressedLen.uint64
 
 proc checkValidFramed(payload: openArray[byte], expected: openArray[byte], checkIntegrity = true) =
   var tmp = newSeqUninit[byte](expected.len)
@@ -136,6 +137,7 @@ suite "framing":
 
   test "just a header":
     checkValidFramed(framingHeader, [])
+    checkValidFramed(@framingHeader & @framingHeader, [])
 
   test "buffer sizes":
     var
@@ -198,6 +200,7 @@ suite "framing":
   test "invalid header":
     checkInvalidFramed([byte 3, 2, 1, 0], 0)
     checkInvalidFramed([byte 0, 0, 0, 0, 42], 0)
+    checkInvalidFramed(@framingHeader & @framingHeader[0 .. ^2] & @[byte 42], 0)
 
   test "overlong frame":
     let


### PR DESCRIPTION
> The stream identifier chunk can come multiple times in the stream
> besides the first; if such a chunk shows up, it should simply be
> ignored, assuming it has the right length and contents. This allows for
> easy concatenation of compressed files without the need for re-framing.

https://github.com/google/snappy/blob/main/framing_format.txt#L76-L79